### PR TITLE
Fixed deprecation warnings

### DIFF
--- a/src/Gregwar/Captcha/CaptchaBuilder.php
+++ b/src/Gregwar/Captcha/CaptchaBuilder.php
@@ -362,7 +362,7 @@ class CaptchaBuilder implements CaptchaBuilderInterface
             $w = $box[2] - $box[0];
             $angle = $this->rand(-$this->maxAngle, $this->maxAngle);
             $offset = $this->rand(-$this->maxOffset, $this->maxOffset);
-            \imagettftext($image, $size, $angle, $x, $y + $offset, $col, $font, $symbol);
+            \imagettftext($image, $size, $angle, (int)$x, (int)$y + $offset, $col, $font, $symbol);
             $x += $w;
         }
 
@@ -605,7 +605,7 @@ class CaptchaBuilder implements CaptchaBuilderInterface
             $value = current($this->fingerprint);
             next($this->fingerprint);
         } else {
-            $value = mt_rand($min, $max);
+            $value = mt_rand((int)$min, (int)$max);
             $this->fingerprint[] = $value;
         }
 


### PR DESCRIPTION
Implicit conversion from float to int changed to explicit conversions to prevent deprecation warnings in lines 365 and 608 [PHP 8.1]